### PR TITLE
fix: Upgrade to latest version and remove Python PEP-668 enforcement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:latest
 
-RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ v0.9.15
+RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ v0.15.0
 
 RUN apk --no-cache add git python3 py3-pip && \
+    find /usr/lib/ -type f -name 'EXTERNALLY-MANAGED' -exec rm -f {} \; && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install codespell


### PR DESCRIPTION
# Why?
1. Your Dockerfile stops building - it makes me sad.

# Changes
- `v0.9.15` no longer exist - Bump to latest on Github https://github.com/reviewdog/reviewdog/releases/tag/v0.15.0
- Remove PEP-668 Enforcement for global installation 
